### PR TITLE
adds dropdown URL and MR link in Cherrypick Form

### DIFF
--- a/src/extension/cherryPickForm.ts
+++ b/src/extension/cherryPickForm.ts
@@ -219,6 +219,9 @@ function renderForm(commits, url, path, commitBranch, targetBranch) {
   tableDiv.appendChild(table);
 
   const tableHead = document.createElement("thead");
+  tableHead.style.position = "sticky";
+  tableHead.style.top = "0";
+  tableHead.style.background = "#FFFFFF";
   table.appendChild(tableHead);
 
   const formHeader = document.createElement("tr");

--- a/src/extension/public/cherrypick.html
+++ b/src/extension/public/cherrypick.html
@@ -21,8 +21,21 @@
           <input
             type="text"
             class="form-control"
+            autocomplete="off"
             id="location"
             name="location"
+            list="url-list"
+          />
+          <datalist id="url-list"></datalist>
+        </div>
+        <div class="form-group col-md-6">
+          <label for="fetchMergeCommitBranch">Fetch Merge Commits From:</label>
+          <input
+            type="text"
+            class="form-control"
+            id="fetchMergeCommitBranch"
+            name="fetchMergeCommitBranch"
+            placeholder="branch to get merge commits from (leave blank to get all merge commits)"
           />
         </div>
       </div>
@@ -34,6 +47,7 @@
             class="form-control"
             id="commitBranch"
             name="commitBranch"
+            placeholder="new branch or existing branch in origin"
           />
         </div>
         <div class="form-group col-md-6">
@@ -43,6 +57,8 @@
             class="form-control"
             id="targetBranch"
             name="targetBranch"
+            placeholder="target branch"
+            ;
           />
         </div>
       </div>
@@ -54,6 +70,8 @@
             class="form-control"
             id="commitAuthor"
             name="commitAuthor"
+            placeholder="email id of author for whom to fetch merge commits for"
+            ;
           />
         </div>
         <div class="form-group col-md-6">

--- a/src/extension/public/options.html
+++ b/src/extension/public/options.html
@@ -23,6 +23,7 @@
             class="form-control"
             id="url"
             name="url"
+            placeholder="Homepage url of the gitLab repo"
             required
           />
         </div>
@@ -33,6 +34,7 @@
             class="form-control"
             id="path"
             name="path"
+            placeholder="absolute path of the local repo"
             required
           />
         </div>

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -106,11 +106,13 @@ app.post("/cherrypick", async function (req, res) {
 
 app.post("/mergecommits", async function (req, res) {
   try {
-    const { commitAuthor, commitTime, location } = req.body;
+    const { commitAuthor, commitTime, fetchMergeCommitBranch, location } =
+      req.body;
     const localRepo = await getLocalRepository(location);
     const jsonResponse = await getMergeCommits(
       commitAuthor,
       commitTime,
+      fetchMergeCommitBranch,
       localRepo
     );
     res.writeHead(200, {

--- a/src/server/cherryPick.ts
+++ b/src/server/cherryPick.ts
@@ -14,11 +14,19 @@ async function cherryPickProcess(req, res) {
         await git(localPath).checkout(commitBranch);
         await git(localPath).raw("reset", "--hard", `origin/${commitBranch}`);
       } catch {
-        try{
-          await git(localPath).checkout(commitBranch);
-        }
-        catch{
+        try {
+          await git(localPath).deleteLocalBranch(commitBranch, true);
           await git(localPath).checkoutBranch(commitBranch, targetBranch);
+          res.write(
+            `Deleted existing branch ${commitBranch} and created new branch ${commitBranch}`
+          );
+          console.log(
+            `Deleted existing branch ${commitBranch} and created new branch ${commitBranch}`
+          );
+        } catch {
+          await git(localPath).checkoutBranch(commitBranch, targetBranch);
+          res.write(`Created new branch ${commitBranch}`);
+          console.log(`Created new branch ${commitBranch}`);
         }
       }
     } else if (requestType === "continue") {


### PR DESCRIPTION
This PR adds a repository URL option with a dropdown and Merge request link in the respective Merge commits.
## Problem:
1. If cherry-pick request was given from anywhere outside the repository, it results in error, but it is hard for users to debug it. Also, when multiple repositories exits with same starting URL, it can cause issues to detect which repo the task it to be performed.
2. It is very hard for users to. search the Merge requests from the commit SHA values.
## Solution:
1. A URL input which is filled by fetching all the URL from the server. If the incoming url matches any of them, it is auto filled or user gets a dropdown with all the URL's to choose from which will be used for cherry-pick.
2. A PR link column in the cherry-pick form which will open a new tab with the respective Merge Request, if the information about MR exists in local system, otherwise No link found is shown.